### PR TITLE
ProgressWindowのis_greater_than_maxを呼ばないように変更

### DIFF
--- a/Contents/scripts/humtools/skinweightsbugsearcher/bug_searcher.py
+++ b/Contents/scripts/humtools/skinweightsbugsearcher/bug_searcher.py
@@ -41,8 +41,6 @@ def __get_bugs(working_mesh, progress_window):
     while not working_mesh.mesh_vert_it_main.isDone():
         if progress_window.is_cancelled():
             break
-        if progress_window.is_greater_than_max():
-            break
         progress_window.next()
 
         nearby_vert_ids = working_mesh.get_vert_ids_nearby_current_vert()

--- a/Contents/scripts/humtools/skinweightsio/deformer_weights_exporter.py
+++ b/Contents/scripts/humtools/skinweightsio/deformer_weights_exporter.py
@@ -24,8 +24,6 @@ class DeformerWeightsExporter:
             # ProgressWindowの更新処理
             if progress_window.is_cancelled():
                 break
-            if progress_window.is_greater_than_max():
-                break
             progress_window.next()
 
             xml_file_name = self.__get_xml_file_name(mesh_parent_transform)

--- a/Contents/scripts/humtools/skinweightsio/deformer_weights_importer.py
+++ b/Contents/scripts/humtools/skinweightsio/deformer_weights_importer.py
@@ -32,8 +32,6 @@ class DeformerWeightsImporter:
             # ProgressWindowの更新処理
             if progress_window.is_cancelled():
                 break
-            if progress_window.is_greater_than_max():
-                break
             progress_window.next()
 
             # XMLがあるか確認


### PR DESCRIPTION
そもそも呼ぶ必要がないため処理時間削減も兼ねて削除