### PR TITLE
Feature/add/interruption

### DIFF
--- a/Contents/scripts/humtools/skinweightsio/deformer_weights_exporter.py
+++ b/Contents/scripts/humtools/skinweightsio/deformer_weights_exporter.py
@@ -20,6 +20,7 @@ class DeformerWeightsExporter:
                                          LangOpVar.get())
         progress_window.show()
 
+        success = False
         for mesh_parent_transform, skin_cluster in mesh_parent_transform_and_skincluster_dict.items():
             # ProgressWindowの更新処理
             if progress_window.is_cancelled():
@@ -31,9 +32,13 @@ class DeformerWeightsExporter:
             xml_file_name = self.__get_xml_file_name(mesh_parent_transform)
             self.__export_xmls(xml_file_name, skin_cluster)
             self.__log(mesh_parent_transform)
+        else:
+            success = True
 
         progress_window.close()
         self.__load_text_scroll_list()
+
+        return success
 
     def __get_xml_file_name(self, mesh_parent_transform):
         return '{}{}'.format(mesh_parent_transform, Extensions.XML)

--- a/Contents/scripts/humtools/skinweightsio/deformer_weights_importer.py
+++ b/Contents/scripts/humtools/skinweightsio/deformer_weights_importer.py
@@ -27,6 +27,7 @@ class DeformerWeightsImporter:
                                          LangOpVar.get())
         progress_window.show()
 
+        success = False
         # NOTE: xmlと同名のメッシュ(メッシュの親トランスフォーム)に自動でウェイトをコピーする
         for mesh_parent_transform, skin_cluster in transform_and_skincluster_dict.items():
             # ProgressWindowの更新処理
@@ -54,9 +55,12 @@ class DeformerWeightsImporter:
                                 'Copied weights to {}.'.format(mesh_parent_transform),
                                 LangOpVar.get())
             Log.log(log_msg)
+        else:
+            success = True  # TODO: Falseの場合はUndoチャンクで囲ってUndoまでする
 
         progress_window.close()
-        # self.__option_settings.log()
+
+        return success
 
     def __get_xml_file_name(self, mesh_parent_transform):
         return '{}{}'.format(mesh_parent_transform, Extensions.XML)

--- a/Contents/scripts/humtools/skinweightsio/deformer_weights_importer.py
+++ b/Contents/scripts/humtools/skinweightsio/deformer_weights_importer.py
@@ -56,7 +56,7 @@ class DeformerWeightsImporter:
                                 LangOpVar.get())
             Log.log(log_msg)
         else:
-            success = True  # TODO: Falseの場合はUndoチャンクで囲ってUndoまでする
+            success = True
 
         progress_window.close()
 

--- a/Contents/scripts/humtools/skinweightsio/main.py
+++ b/Contents/scripts/humtools/skinweightsio/main.py
@@ -20,9 +20,9 @@ def create_xml(xmls_folder_path, xml_text_scroll_list):
     mesh_parent_transform_and_skincluster_dict = mesh_parent_transform_and_skincluster_dict_getter.get_for_export(mesh_parent_transforms)
 
     deformer_weights_exporter = DeformerWeightsExporter(xmls_folder_path, xml_text_scroll_list)
-    deformer_weights_exporter.export_xmls(mesh_parent_transform_and_skincluster_dict)
+    success = deformer_weights_exporter.export_xmls(mesh_parent_transform_and_skincluster_dict)
 
-    __show_completion_message()
+    __show_completion_message(success)
 
 
 @UnexpectedError.catch
@@ -41,9 +41,9 @@ def copy_weights(xmls_folder_path, option_settings):
         __raise_copy_weights_err()
 
     deformer_weights_importer = DeformerWeightsImporter(xmls_folder_path, option_settings)
-    deformer_weights_importer.import_xmls(transform_and_skincluster_dict_normalized)
+    success = deformer_weights_importer.import_xmls(transform_and_skincluster_dict_normalized)
 
-    __show_completion_message()
+    __show_completion_message(success)
 
 
 def __raise_copy_weights_err():
@@ -61,5 +61,8 @@ def __raise_copy_weights_err():
     raise UnexpectedError(err_msg)
 
 
-def __show_completion_message():
-    in_view_message.show(Lang.pack(u"処理が完了しました。", 'The process has been completed.', LangOpVar.get()))
+def __show_completion_message(success):
+    if success:
+        in_view_message.show(Lang.pack(u"処理が完了しました。", 'The process has been completed.', LangOpVar.get()))
+    else:
+        in_view_message.show(Lang.pack(u"処理を中断しました。", 'Processing has been interrupted.', LangOpVar.get()))


### PR DESCRIPTION
処理を中断した場合のinViewMessageを追加

https://github.com/Hum9183/MayaHumTools/issues/6 に対応しようとしたが`cmds.deformerWeights()`をundoしたときの動作が不安定なためオミット